### PR TITLE
Rework the names of metrics

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -54,7 +54,7 @@ func (e *Exporter) newCollector() *collector {
 		idleProcesses:      newFuncMetric("idle_processes", "Idle process count"),
 		activeProcesses:    newFuncMetric("active_processes", "Active process count"),
 		totalProcesses:     newFuncMetric("total_processes", "Total process count"),
-		maxActiveProcesses: newFuncMetric("max_active_processes", "Maximum active process count"),
+		maxActiveProcesses: newFuncMetric("active_max_processes", "Maximum active process count"),
 		maxChildrenReached: newFuncMetric("max_children_reached", "Number of times the process limit has been reached"),
 		slowRequests:       newFuncMetric("slow_requests", "Number of requests that exceed request_slowlog_timeout"),
 		scrapeFailures:     newFuncMetric("scrape_failures", "Number of errors while scraping php_fpm"),

--- a/collector.go
+++ b/collector.go
@@ -55,7 +55,7 @@ func (e *Exporter) newCollector() *collector {
 		activeProcesses:    newFuncMetric("active_processes", "Active process count"),
 		totalProcesses:     newFuncMetric("total_processes", "Total process count"),
 		maxActiveProcesses: newFuncMetric("active_max_processes", "Maximum active process count"),
-		maxChildrenReached: newFuncMetric("max_children_reached", "Number of times the process limit has been reached"),
+		maxChildrenReached: newFuncMetric("max_children_reached_total", "Number of times the process limit has been reached"),
 		slowRequests:       newFuncMetric("slow_requests", "Number of requests that exceed request_slowlog_timeout"),
 		scrapeFailures:     newFuncMetric("scrape_failures", "Number of errors while scraping php_fpm"),
 	}

--- a/collector.go
+++ b/collector.go
@@ -50,7 +50,7 @@ func (e *Exporter) newCollector() *collector {
 		acceptedConn:       newFuncMetric("accepted_connections_total", "Total number of accepted connections"),
 		listenQueue:        newFuncMetric("listen_queue_connections", "Number of connections that have been initiated but not yet accepted"),
 		maxListenQueue:     newFuncMetric("listen_queue_max_connections", "Max number of connections the listen queue has reached since FPM start"),
-		listenQueueLength:  newFuncMetric("listen_queue_length", "Maximum number of connections that can be queued"),
+		listenQueueLength:  newFuncMetric("listen_queue_length_connections", "The length of the socket queue, dictating maximum number of pending connections"),
 		idleProcesses:      newFuncMetric("idle_processes", "Idle process count"),
 		activeProcesses:    newFuncMetric("active_processes", "Active process count"),
 		totalProcesses:     newFuncMetric("total_processes", "Total process count"),

--- a/collector.go
+++ b/collector.go
@@ -49,7 +49,7 @@ func (e *Exporter) newCollector() *collector {
 		up:                 newFuncMetric("up", "able to contact php-fpm"),
 		acceptedConn:       newFuncMetric("accepted_connections_total", "Total number of accepted connections"),
 		listenQueue:        newFuncMetric("listen_queue_connections", "Number of connections that have been initiated but not yet accepted"),
-		maxListenQueue:     newFuncMetric("max_listen_queue", "Max. connections the listen queue has reached since FPM start"),
+		maxListenQueue:     newFuncMetric("listen_queue_max_connections", "Max number of connections the listen queue has reached since FPM start"),
 		listenQueueLength:  newFuncMetric("listen_queue_length", "Maximum number of connections that can be queued"),
 		idleProcesses:      newFuncMetric("idle_processes", "Idle process count"),
 		activeProcesses:    newFuncMetric("active_processes", "Active process count"),

--- a/collector.go
+++ b/collector.go
@@ -56,7 +56,7 @@ func (e *Exporter) newCollector() *collector {
 		totalProcesses:     newFuncMetric("total_processes", "Total process count"),
 		maxActiveProcesses: newFuncMetric("active_max_processes", "Maximum active process count"),
 		maxChildrenReached: newFuncMetric("max_children_reached_total", "Number of times the process limit has been reached"),
-		slowRequests:       newFuncMetric("slow_requests", "Number of requests that exceed request_slowlog_timeout"),
+		slowRequests:       newFuncMetric("slow_requests_total", "Number of requests that exceed request_slowlog_timeout"),
 		scrapeFailures:     newFuncMetric("scrape_failures", "Number of errors while scraping php_fpm"),
 	}
 }

--- a/collector.go
+++ b/collector.go
@@ -47,7 +47,7 @@ func (e *Exporter) newCollector() *collector {
 	return &collector{
 		exporter:           e,
 		up:                 newFuncMetric("up", "able to contact php-fpm"),
-		acceptedConn:       newFuncMetric("accepted_conn", "Total of accepted connections"),
+		acceptedConn:       newFuncMetric("accepted_connections_total", "Total number of accepted connections"),
 		listenQueue:        newFuncMetric("listen_queue", "Number of connections that have been initiated but not yet accepted"),
 		maxListenQueue:     newFuncMetric("max_listen_queue", "Max. connections the listen queue has reached since FPM start"),
 		listenQueueLength:  newFuncMetric("listen_queue_length", "Maximum number of connections that can be queued"),

--- a/collector.go
+++ b/collector.go
@@ -57,7 +57,7 @@ func (e *Exporter) newCollector() *collector {
 		maxActiveProcesses: newFuncMetric("active_max_processes", "Maximum active process count"),
 		maxChildrenReached: newFuncMetric("max_children_reached_total", "Number of times the process limit has been reached"),
 		slowRequests:       newFuncMetric("slow_requests_total", "Number of requests that exceed request_slowlog_timeout"),
-		scrapeFailures:     newFuncMetric("scrape_failures", "Number of errors while scraping php_fpm"),
+		scrapeFailures:     newFuncMetric("scrape_failures_total", "Number of errors while scraping php_fpm"),
 	}
 }
 

--- a/collector.go
+++ b/collector.go
@@ -48,7 +48,7 @@ func (e *Exporter) newCollector() *collector {
 		exporter:           e,
 		up:                 newFuncMetric("up", "able to contact php-fpm"),
 		acceptedConn:       newFuncMetric("accepted_connections_total", "Total number of accepted connections"),
-		listenQueue:        newFuncMetric("listen_queue", "Number of connections that have been initiated but not yet accepted"),
+		listenQueue:        newFuncMetric("listen_queue_connections", "Number of connections that have been initiated but not yet accepted"),
 		maxListenQueue:     newFuncMetric("max_listen_queue", "Max. connections the listen queue has reached since FPM start"),
 		listenQueueLength:  newFuncMetric("listen_queue_length", "Maximum number of connections that can be queued"),
 		idleProcesses:      newFuncMetric("idle_processes", "Idle process count"),


### PR DESCRIPTION
Currently, the metrics appear to be fashioned after the PHP status page. While this is easy for those used to consuming the PHP status page to understand, it is not as easy for consumers of Prometheus to understand. 

This work revises the metric names such that they are expressed in a more expected way to prometheus, such that users who are familiar with Prometheus but not with PHP are able to query PHP for state, and make some judgements as to its health.