### PR TITLE
Add support for fcgi via unix sockets

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -72,8 +72,13 @@ func (c *collector) Describe(ch chan<- *prometheus.Desc) {
 
 func getDataFastcgi(u *url.URL) ([]byte, error) {
 	path := u.Path
-	if path == "" {
+	host := u.Host
+
+	if path == "" || u.Scheme == "unix" {
 		path = "/status"
+	}
+	if u.Scheme == "unix" {
+		host = u.Path
 	}
 
 	env := map[string]string{
@@ -81,7 +86,7 @@ func getDataFastcgi(u *url.URL) ([]byte, error) {
 		"SCRIPT_NAME":     path,
 	}
 
-	fcgi, err := fcgiclient.Dial(u.Scheme, u.Host)
+	fcgi, err := fcgiclient.Dial(u.Scheme, host)
 	if err != nil {
 		return nil, errors.Wrap(err, "fastcgi dial failed")
 	}


### PR DESCRIPTION
As it is, the exporter will throw the following error when trying to scrape from a fcgi endpoint via unix sockets as explained in the README (in my case with unix:///run/php-fpm/php-fpm.sock):

    {"level":"error","ts":1525910529.0031693,"msg":"failed to get php-fpm status","error":"fastcgi dial failed: dial unix: missing address","errorVerbose":"dial unix: missing address\nfastcgi dial failed\ngithub.com/bakins/php-fpm-exporter.getDataFastcgi\n\t/home/jakob/go/src/github.com/bakins/php-fpm-exporter/collector.go:86\ngithub.com/bakins/php-fpm-exporter.(*collector).Collect\n\t/home/jakob/go/src/github.com/bakins/php-fpm-exporter/collector.go:148\ngithub.com/bakins/php-fpm-exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func2\n\t/home/jakob/go/src/github.com/bakins/php-fpm-exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:433\nruntime.goexit\n\t/usr/lib/go/src/runtime/asm_amd64.s:2361"}

With this PR, it works as intended.