### PR TITLE
fix #20 - check if URL is an empty string

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -144,7 +144,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		err  error
 	)
 
-	if c.exporter.fcgiEndpoint != nil {
+	if c.exporter.fcgiEndpoint != nil && c.exporter.fcgiEndpoint.String() != "" {
 		body, err = getDataFastcgi(c.exporter.fcgiEndpoint)
 	} else {
 		body, err = getDataHTTP(c.exporter.endpoint)


### PR DESCRIPTION
It is not necessary to check for empty strings in the raw URLs as the associated DIal functions will fail appropriately. However, in the case of FastCGI you want to default to HTTP so checking for an empty URL is needed.

You would be able to remove the checks adding in commit 9a63716c8569bcdbb071d375ba4d188f6bc976f6 with this patch.