### PR TITLE
Add support for timeouts

### DIFF
--- a/cmd/php-fpm-exporter/main.go
+++ b/cmd/php-fpm-exporter/main.go
@@ -13,6 +13,7 @@ func main() {
 		endpoint        = kingpin.Flag("endpoint", "url for php-fpm status").Default("http://127.0.0.1:9000/status").Envar("ENDPOINT_URL").String()
 		fcgiEndpoint    = kingpin.Flag("fastcgi", "fastcgi url. If this is set, fastcgi will be used instead of HTTP").Envar("FASTCGI_URL").String()
 		metricsEndpoint = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics. Cannot be /").Default("/metrics").Envar("TELEMETRY_PATH").String()
+		statusTimeout   = kingpin.Flag("status.timeout", "Scrape timeout for php-fpm status. If unset, then will wait forever.").Envar("STATUS_TIMEOUT").Duration()
 	)
 
 	kingpin.HelpFlag.Short('h')
@@ -29,6 +30,7 @@ func main() {
 		exporter.SetFastcgi(*fcgiEndpoint),
 		exporter.SetLogger(logger),
 		exporter.SetMetricsEndpoint(*metricsEndpoint),
+		exporter.SetStatusTimeout(statusTimeout),
 	)
 
 	if err != nil {

--- a/collector.go
+++ b/collector.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -70,7 +71,8 @@ func (c *collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.slowRequests
 }
 
-func getDataFastcgi(u *url.URL) ([]byte, error) {
+func (c *collector) getDataFastcgi() ([]byte, error) {
+	u := c.exporter.fcgiEndpoint
 	path := u.Path
 	host := u.Host
 
@@ -86,12 +88,16 @@ func getDataFastcgi(u *url.URL) ([]byte, error) {
 		"SCRIPT_NAME":     path,
 	}
 
-	fcgi, err := fcgiclient.Dial(u.Scheme, host)
+	fcgi, err := fcgiclient.DialTimeout(u.Scheme, host, c.exporter.statusTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "fastcgi dial failed")
 	}
 
 	defer fcgi.Close()
+
+	if err = fcgi.SetTimeout(c.exporter.statusTimeout); err != nil {
+		return nil, errors.Wrap(err, "fastcgi SetTimeout failed")
+	}
 
 	resp, err := fcgi.Get(env)
 	if err != nil {
@@ -112,7 +118,8 @@ func getDataFastcgi(u *url.URL) ([]byte, error) {
 	return body, nil
 }
 
-func getDataHTTP(u *url.URL) ([]byte, error) {
+func (c *collector) getDataHTTP() ([]byte, error) {
+	u := c.exporter.endpoint
 	req := http.Request{
 		Method:     "GET",
 		URL:        u,
@@ -123,7 +130,7 @@ func getDataHTTP(u *url.URL) ([]byte, error) {
 		Host:       u.Host,
 	}
 
-	resp, err := http.DefaultClient.Do(&req)
+	resp, err := (&http.Client{Timeout: c.exporter.statusTimeout}).Do(&req)
 	if err != nil {
 		return nil, errors.Wrap(err, "HTTP request failed")
 	}
@@ -150,9 +157,9 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	)
 
 	if c.exporter.fcgiEndpoint != nil && c.exporter.fcgiEndpoint.String() != "" {
-		body, err = getDataFastcgi(c.exporter.fcgiEndpoint)
+		body, err = c.getDataFastcgi()
 	} else {
-		body, err = getDataHTTP(c.exporter.endpoint)
+		body, err = c.getDataHTTP()
 	}
 
 	if err != nil {

--- a/exporter.go
+++ b/exporter.go
@@ -24,6 +24,7 @@ type Exporter struct {
 	fcgiEndpoint    *url.URL
 	logger          *zap.Logger
 	metricsEndpoint string
+	statusTimeout   time.Duration
 }
 
 // OptionsFunc is a function passed to new for setting options on a new Exporter.
@@ -120,6 +121,19 @@ func SetMetricsEndpoint(path string) func(*Exporter) error {
 			return nil
 		}
 		e.metricsEndpoint = path
+		return nil
+	}
+}
+
+// SetStatusTimeout sets the timeout for a request to the fpm status endpoint.
+// Generally only used when create a new Exporter.
+func SetStatusTimeout(timeout *time.Duration) func(*Exporter) error {
+	return func(e *Exporter) error {
+		if timeout == nil {
+			e.statusTimeout = 0
+		} else {
+			e.statusTimeout = *timeout
+		}
 		return nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,7 @@ require (
 	golang.org/x/sync v0.0.0-20170418210838-de49d9dcd27d
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
+
+replace (
+	github.com/tomasen/fcgi_client => github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7
+)

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v0.0.0-20170331031902-2bba0603135d h1:KmiEmEGA5sqizMpKnexwioxj8zEUSBc7p9UTQu36lpQ=
 github.com/golang/protobuf v0.0.0-20170331031902-2bba0603135d/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7 h1:W0fAsQ7bC1db4k9O2X6yZvatz/0c/ISyxhmNnc6arZA=
+github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7/go.mod h1:dHpIS7C6YjFguh5vo9QBVEojDoL3vh3v6oEho2HtNyA=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,23 +18,23 @@ github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.0.0-20170220103846-49fee292b27b
 github.com/prometheus/common/expfmt
-github.com/prometheus/common/model
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
+github.com/prometheus/common/model
 # github.com/prometheus/procfs v0.0.0-20170216223256-a1dba9ce8bae
 github.com/prometheus/procfs
 github.com/prometheus/procfs/xfs
-# github.com/tomasen/fcgi_client v0.0.0-20171212193905-d32b71631a94
+# github.com/tomasen/fcgi_client v0.0.0-20171212193905-d32b71631a94 => github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7
 github.com/tomasen/fcgi_client
 # go.uber.org/atomic v1.3.1
 go.uber.org/atomic
 # go.uber.org/zap v1.4.1
 go.uber.org/zap
-go.uber.org/zap/internal/bufferpool
-go.uber.org/zap/internal/multierror
-go.uber.org/zap/zapcore
 go.uber.org/zap/buffer
+go.uber.org/zap/internal/bufferpool
 go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
+go.uber.org/zap/internal/multierror
+go.uber.org/zap/zapcore
 # golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2
 golang.org/x/net/context
 # golang.org/x/sync v0.0.0-20170418210838-de49d9dcd27d


### PR DESCRIPTION
# Description

Currently, the exporter will hang forever on a hung php-fpm that is not accepting on the socket or is not replying with a status page. You can reproduce this by e.g. sending SIGSTOP to the php-fpm processes and seeing that the exporter never reports a failure, rather prometheus starts timing out trying to scrape it.

# PR Overview

- Adds a `--status.timeout` (env var `STATUS_TIMEOUT`) cli flag, defaults to 0 which means no timeout and is the current behavior.
- Uses this timeout in HTTP client
- Uses this timeout in FCGI client
  - NOTE: we replace `github.com/tomasen/fcgi_client => github.com/kanocz/fcgi_client` in go.mod to get a forked fcgi_client module that also supports timeouts. This is basically including https://github.com/tomasen/fcgi_client/pull/12 as a net result. 