### PR TITLE
update call to NewProcessCollector

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -137,7 +137,7 @@ func (e *Exporter) Run() error {
 	if err := prometheus.Register(c); err != nil {
 		return errors.Wrap(err, "failed to register metrics")
 	}
-	prometheus.Unregister(prometheus.NewProcessCollector(os.Getpid(), ""))
+	prometheus.Unregister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 	prometheus.Unregister(prometheus.NewGoCollector())
 
 	http.HandleFunc("/healthz", e.healthz)


### PR DESCRIPTION
While trying to build the code, got the following error :

```
./exporter.go:140:68: too many arguments in call to prometheus.NewProcessCollector
        have (int, string)
        want (prometheus.ProcessCollectorOpts)
```

Fixed by using the default struct 