### PR TITLE
DOPS-5632: modify script and dockerfile to support arm64 and amd64 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 php-fpm-exporter.darwin.amd64
 php-fpm-exporter.linux.amd64
 *.sha256.txt
+php-fpm-exporter.darwin.arm64
+php-fpm-exporter.linux.arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM       golang:alpine as builder
+ARG ARCH=amd64
+FROM --platform=linux/${ARCH} golang:1.22-alpine AS builder
 
 RUN apk --no-cache add bash make openssl
-COPY . /go/src/github.com/bakins/php-fpm-exporter
-RUN cd /go/src/github.com/bakins/php-fpm-exporter && ./script/build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -o /php-fpm-exporter ./cmd/php-fpm-exporter
 
-FROM scratch
-COPY --from=builder /go/src/github.com/bakins/php-fpm-exporter/php-fpm-exporter.linux.amd64 /php-fpm-exporter
+FROM --platform=linux/${ARCH} alpine:3.19
+COPY --from=builder /php-fpm-exporter /php-fpm-exporter
 
-ENTRYPOINT [ "/php-fpm-exporter" ]
+ENTRYPOINT ["/php-fpm-exporter"]

--- a/exporter.go
+++ b/exporter.go
@@ -137,7 +137,10 @@ func (e *Exporter) Run() error {
 	if err := prometheus.Register(c); err != nil {
 		return errors.Wrap(err, "failed to register metrics")
 	}
-	prometheus.Unregister(prometheus.NewProcessCollector(os.Getpid(), ""))
+	prometheus.Unregister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{
+		PidFn: func() (int, error) { return os.Getpid(), nil },
+		Namespace: "",
+	}))
 	prometheus.Unregister(prometheus.NewGoCollector())
 
 	http.HandleFunc("/healthz", e.healthz)

--- a/script/build
+++ b/script/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 NAME=php-fpm-exporter
-ARCH=amd64
+ARCH=${1:-amd64}
 
 export GOFLAGS=-mod=vendor
 export GO111MODULE=on
@@ -9,6 +9,6 @@ export GO111MODULE=on
 for OS in darwin linux; do
     FILE=${NAME}.${OS}.${ARCH}
     CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -o ${FILE} ./cmd/${NAME}
-    SHA=`openssl sha256 ${FILE} | awk '{print $2}'`
+    SHA=$(openssl sha256 ${FILE} | awk '{print $2}')
     echo "${SHA} ${FILE}" > ${FILE}.sha256.txt
 done


### PR DESCRIPTION
This pull request introduces improvements to the build process, Dockerfile configuration, and metrics registration logic. The most significant changes include adding support for multi-architecture builds, refactoring the Dockerfile for better maintainability, and updating the Prometheus metrics collector registration.

### Build process improvements:
* [`script/build`](diffhunk://#diff-99b83631df533ea1d9c97396a043a4670464f523d0c1e60b0a1cab6dddd440f9L4-R12): Modified the build script to accept an optional architecture argument (`ARCH`) instead of hardcoding it to `amd64`. This enables multi-architecture builds. Additionally, replaced backticks with `$()` for better readability and consistency in the SHA256 checksum calculation.

### Dockerfile updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R10): Refactored to support multi-architecture builds using the `--platform` flag and `ARG ARCH`. Simplified the build process by using a single `WORKDIR` and updated the `RUN` command to directly build the binary with the specified architecture. Replaced the `scratch` image with `alpine:3.19` for the final stage.

### Metrics registration refactor:
* [`exporter.go`](diffhunk://#diff-e4987a222ab3e846614998485952d8ee42288062a30929290cf3ea0e815d5ae1L140-R143): Updated the `prometheus.NewProcessCollector` call to use `ProcessCollectorOpts` with a `PidFn` function, improving flexibility and readability in the metrics registration logic.